### PR TITLE
Set encoding to Binary for MTOM Attachments

### DIFF
--- a/lib/savon/builder.rb
+++ b/lib/savon/builder.rb
@@ -262,8 +262,14 @@ module Savon
     def init_multipart_message(message_xml)
       multipart_message = Mail.new
 
+      # MTOM differs from general SOAP attachments:
+      # 1. binary encoding
+      # 2. application/xop+xml mime type
       if @locals[:mtom]
         type = "application/xop+xml; charset=#{@globals[:encoding]}; type=\"text/xml\""
+
+        multipart_message.transport_encoding = 'binary'
+        message_xml.force_encoding('BINARY')
       else
         type = 'text/xml'
       end

--- a/lib/savon/operation.rb
+++ b/lib/savon/operation.rb
@@ -101,7 +101,7 @@ module Savon
       request.body = builder.to_s
 
       if builder.multipart
-        request.gzip
+        request.gzip unless @locals[:mtom]
         request.headers["Content-Type"] = content_type_header(builder)
         request.headers["MIME-Version"] = "1.0"
       end

--- a/lib/savon/request_logger.rb
+++ b/lib/savon/request_logger.rb
@@ -47,7 +47,7 @@ module Savon
     end
 
     def body_to_log(body)
-      LogMessage.new(body, @globals[:filters], @globals[:pretty_print_xml]).to_s
+      LogMessage.new(body, @globals[:filters], @globals[:pretty_print_xml]).to_s.force_encoding(@globals[:encoding])
     end
 
   end


### PR DESCRIPTION
Previously attachments were sent in Base64 and WSO2 accepted them fine, until we hit the size treshold and WSO2 started to cache larger files and this lead to broken files (files remained in Base64 not in Binary).

Additional code taken from:
https://github.com/savonrb/savon/pull/944/files#diff-5a4c518121b3117561233cad78d43354f8424514a186ddd1459ab431178a667eR275-R276

**What kind of change is this?**

<!-- E.g. a bugfix, feature, refactoring, build change, etc… -->

**Did you add tests for your changes?**

<!-- Note that we won't merge your changes if you don't add tests -->

**Summary of changes**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Other information**
